### PR TITLE
Busybox's tail fix

### DIFF
--- a/coreutils/tail.c
+++ b/coreutils/tail.c
@@ -335,66 +335,83 @@ int tail_main(int argc, char **argv)
 
 	fmt = NULL;
 
-	if (FOLLOW) while (1) {
-		sleep(sleep_period);
+	if (FOLLOW) {
+		int8_t *reopen_file_flag = xmalloc(sizeof(int8_t) * nfiles);
+		memset(reopen_file_flag, 0, sizeof(int8_t) * nfiles);
 
-		i = 0;
-		do {
-			int nread;
-			const char *filename = argv[i];
-			int fd = fds[i];
+		while (1) {
+			sleep(sleep_period);
 
-			if (FOLLOW_RETRY) {
-				struct stat sbuf, fsbuf;
+			i = 0;
+			do {
+				int nread;
+				const char *filename = argv[i];
+				int fd = fds[i];
 
-				if (fd < 0
-				 || fstat(fd, &fsbuf) < 0
-				 || stat(filename, &sbuf) < 0
-				 || fsbuf.st_dev != sbuf.st_dev
-				 || fsbuf.st_ino != sbuf.st_ino
-				) {
-					int new_fd;
+				if (FOLLOW_RETRY) {
+					struct stat sbuf, fsbuf;
 
-					if (fd >= 0)
-						close(fd);
-					new_fd = open(filename, O_RDONLY);
-					if (new_fd >= 0) {
-						bb_error_msg("%s has %s; following end of new file",
-							filename, (fd < 0) ? "appeared" : "been replaced"
-						);
-					} else if (fd >= 0) {
-						bb_perror_msg("%s has become inaccessible", filename);
+					if (reopen_file_flag[i]) {
+						int new_fd;
+
+						reopen_file_flag[i] = 0;
+						new_fd = open(filename, O_RDONLY);
+						if (new_fd >= 0) {
+							bb_error_msg("%s has %s; following end of new file",
+								filename, (fd < 0) ? "appeared" : "been replaced"
+							);
+						} else if (fd >= 0) {
+							bb_perror_msg("%s has become inaccessible", filename);
+						}
+
+						if (fd >= 0)
+							close(fd);
+
+						fds[i] = fd = new_fd;
 					}
-					fds[i] = fd = new_fd;
-				}
-			}
-			if (ENABLE_FEATURE_FANCY_TAIL && fd < 0)
-				continue;
-			if (nfiles > header_threshhold) {
-				fmt = header_fmt_str;
-			}
-			for (;;) {
-				/* tail -f keeps following files even if they are truncated */
-				struct stat sbuf;
-				/* /proc files report zero st_size, don't lseek them */
-				if (fstat(fd, &sbuf) == 0 && sbuf.st_size > 0) {
-					off_t current = lseek(fd, 0, SEEK_CUR);
-					if (sbuf.st_size < current)
-						xlseek(fd, 0, SEEK_SET);
-				}
 
-				nread = tail_read(fd, tailbuf, BUFSIZ);
-				if (nread <= 0)
-					break;
-				if (fmt && (fd != prev_fd)) {
-					tail_xprint_header(fmt, filename);
-					fmt = NULL;
-					prev_fd = fd;
+					if (fd < 0
+					 || fstat(fd, &fsbuf) < 0
+					 || stat(filename, &sbuf) < 0) {
+						reopen_file_flag[i] = 1;
+						continue;
+					}
+
+					if (fsbuf.st_dev != sbuf.st_dev
+					 || fsbuf.st_ino != sbuf.st_ino) {
+						reopen_file_flag[i] = 1;
+					}
 				}
-				xwrite(STDOUT_FILENO, tailbuf, nread);
-			}
-		} while (++i < nfiles);
-	} /* while (1) */
+				if (ENABLE_FEATURE_FANCY_TAIL && fd < 0)
+					continue;
+				if (nfiles > header_threshhold) {
+					fmt = header_fmt_str;
+				}
+				for (;;) {
+					/* tail -f keeps following files even if they are truncated */
+					struct stat sbuf;
+					/* /proc files report zero st_size, don't lseek them */
+					if (fstat(fd, &sbuf) == 0 && sbuf.st_size > 0) {
+						off_t current = lseek(fd, 0, SEEK_CUR);
+						if (sbuf.st_size < current)
+							xlseek(fd, 0, SEEK_SET);
+					}
+
+					nread = tail_read(fd, tailbuf, BUFSIZ);
+					if (nread <= 0)
+						break;
+					if (fmt && (fd != prev_fd)) {
+						tail_xprint_header(fmt, filename);
+						fmt = NULL;
+						prev_fd = fd;
+					}
+					xwrite(STDOUT_FILENO, tailbuf, nread);
+				}
+			} while (++i < nfiles);
+		} /* while (1) */
+
+		free(reopen_file_flag);
+	}
 
 	if (ENABLE_FEATURE_CLEAN_UP) {
 		free(fds);


### PR DESCRIPTION
When file rotates, make sure to read remaining content from the old file.